### PR TITLE
Try Jest instead of ViTest

### DIFF
--- a/2022/Day01/solution.ts
+++ b/2022/Day01/solution.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { readData } from '../utils'
 
 const sample: string[] = `
@@ -60,17 +59,17 @@ function part1_2(input: string[], top: number): number {
 describe('Day 1', () => {
     const input = readData(__dirname)
 
-    test('part 1', () => {
+    it('part 1', () => {
         expect(part1(sample)).toBe(24000)
         expect(part1(input)).toBe(67027)
     })
 
-    test('part 2', () => {
+    it('part 2', () => {
         expect(part2(sample)).toBe(45000)
         expect(part2(input)).toBe(197291)
     })
     
-    test('combined', () => {
+    it('combined', () => {
         expect(part1_2(input, 1)).toBe(67027)
         expect(part1_2(input, 3)).toBe(197291)
     })

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ Running `npm test` will execute all the existing tests.
 
 # IDE support
 
-For IntelliJ Ultimate, the built-in debugging support should allow to directly execute individual tests. For VS-Code,
-you should first install the `Vitest` extension from the official Vs-Code extension marketplace.
+### IntelliJ
+For IntelliJ Ultimate, the built-in debugging support should allow to directly execute individual tests. 
+
+### VS-Code
+For VS-Code, you should first install the [Jest (by Orta)](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest) extension from the official Vs-Code extension marketplace.
+
 
 [Advent of Code]: https://adventofcode.com/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/202[23]/**/*.[jt]s?(x)'],
+  testPathIgnorePatterns: ["/node_modules/", "utils.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "devDependencies": {
+    "@types/jest": "^29.5.7",
     "@types/node": "^20.8.10",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2",
-    "vitest": "^1.0.0-beta.3"
+    "typescript": "^5.2.2"
   },
   "scripts": {
-    "test": "vitest --run",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "clean": "rm -rf node_modules package-lock.json"
-  },
-    "type": "module"
+  }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['2022/Day**/*.ts']
-  },
-})


### PR DESCRIPTION
This PR updates the test running for VS code from ViTest to Jest. 

ViTest plugin seems to have bugs related to node version managers.

Jest was seamless for me